### PR TITLE
Fix jsdoc example for Levenshtein distance

### DIFF
--- a/src/string-levenshtein.js
+++ b/src/string-levenshtein.js
@@ -45,7 +45,7 @@ var ccc = [];
  * @return {number} levenshtein distance between `str1` and `str2`.
  * @example
  * levenshtein( 'example', 'sample' );
- * // ->  3
+ * // ->  2
  * levenshtein( 'distance', 'difference' );
  * // -> 5
  */


### PR DESCRIPTION
`levenshtein( 'example', 'sample' )` ~> 2

Thanks for the nice lib!